### PR TITLE
improvement: add ability to proces query paramters, re-factor to split up routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-hyper-template"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "http-body-util",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # shuttle-hyper-template Cargo.toml definition
 [package]
 name = "shuttle-hyper-template"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2024"
 authors = ["Jeffery D. Mitchell", "<crusty-rustacean@jeff-mitchell.dev>"]
 description = "A template server, built with Hyper and Tokio"

--- a/src/lib/actors/ping.rs
+++ b/src/lib/actors/ping.rs
@@ -20,7 +20,7 @@ pub struct PingCounterActor {
 
 impl PingCounterActor {
     pub fn start_ping_actor() -> (Sender<PingMessage>, JoinHandle<()>) {
-        let (tx, rx) = mpsc::channel(32);
+        let (tx, rx) = mpsc::channel::<PingMessage>(32);
 
         let ping_actor = PingCounterActor { rx, count: 0 };
 
@@ -44,6 +44,6 @@ impl PingCounterActor {
             }
         }
 
-        tracing::info!("PingCounterActor shutting donw.");
+        tracing::info!("PingCounterActor shutting down.");
     }
 }

--- a/src/lib/init.rs
+++ b/src/lib/init.rs
@@ -1,9 +1,9 @@
 // src/lib/init.rs
 
 // dependencies
-use crate::routes::router::HandlerFn;
 use crate::routes::router_table::RouteTable;
-use crate::routes::{handle_count, handle_health_check, handle_metrics, handle_ping};
+use crate::routes::{handle_count, handle_echo, handle_health_check, handle_metrics, handle_ping};
+use crate::types::HandlerFn;
 use hyper::Method;
 
 pub fn build_route_table() -> RouteTable {
@@ -13,6 +13,7 @@ pub fn build_route_table() -> RouteTable {
     table.insert(Method::GET, "/ping", handle_ping as HandlerFn);
     table.insert(Method::GET, "/count", handle_count as HandlerFn);
     table.insert(Method::GET, "/metrics", handle_metrics);
+    table.insert(Method::GET, "/echo", handle_echo);
 
     table
 }

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -7,6 +7,7 @@ pub mod init;
 pub mod routes;
 pub mod service;
 pub mod state;
+pub mod types;
 pub mod utilities;
 
 // re-exports

--- a/src/lib/routes/count.rs
+++ b/src/lib/routes/count.rs
@@ -1,0 +1,38 @@
+// src/lib/routes/count.rs
+
+// dependencies
+use crate::actors::ping::PingMessage;
+use crate::errors::ApiError;
+use crate::state::AppState;
+use crate::types::HandlerResult;
+use crate::utilities::{json_response_msg, set_content_type_json};
+use hyper::{Request, Response, body::Incoming};
+use serde::Serialize;
+use tokio::sync::oneshot;
+
+// struct type to represent a response body from the /count endpoint
+#[derive(Serialize)]
+struct CountResponse {
+    count: usize,
+}
+
+// count handler function
+pub fn handle_count(_request: Request<Incoming>, state: AppState) -> HandlerResult {
+    Box::pin(async move {
+        tracing::info!("Count endpoint reached");
+
+        let (tx, rx) = oneshot::channel();
+        state
+            .ping_tx
+            .send(PingMessage::GetCount(tx))
+            .await
+            .map_err(|_| ApiError::ActorUnavailable)?;
+
+        let count = rx.await?;
+
+        let mut response = Response::new(json_response_msg(CountResponse { count }));
+        set_content_type_json(&mut response);
+
+        Ok(response)
+    })
+}

--- a/src/lib/routes/echo.rs
+++ b/src/lib/routes/echo.rs
@@ -1,0 +1,21 @@
+// src/lib/routes/echo.rs
+
+// dependencies
+use crate::state::AppState;
+use crate::types::HandlerResult;
+use crate::utilities::{json_response_msg, parse_query_string, set_content_type_json};
+use hyper::{Request, Response, body::Incoming};
+
+// echo handler function
+pub fn handle_echo(request: Request<Incoming>, _state: AppState) -> HandlerResult {
+    Box::pin(async move {
+        tracing::info!("Echo endpoint reached");
+        let query = request.uri().query().unwrap_or("");
+        let parsed = parse_query_string(query);
+
+        let mut response = Response::new(json_response_msg(parsed));
+        set_content_type_json(&mut response);
+
+        Ok(response)
+    })
+}

--- a/src/lib/routes/health.rs
+++ b/src/lib/routes/health.rs
@@ -1,0 +1,15 @@
+// src/lib/routes/health.rs
+
+// dependencies
+use crate::state::AppState;
+use crate::types::HandlerResult;
+use crate::utilities::empty;
+use hyper::{Request, Response, body::Incoming};
+
+// health check handler function
+pub fn handle_health_check(_req: Request<Incoming>, _state: AppState) -> HandlerResult {
+    Box::pin(async move {
+        tracing::info!("Health check endpoint reached");
+        Ok(Response::new(empty()))
+    })
+}

--- a/src/lib/routes/metrics.rs
+++ b/src/lib/routes/metrics.rs
@@ -1,0 +1,29 @@
+// src/lib/routes/metrics.rs
+
+// dependencies
+use crate::errors::ApiError;
+use crate::state::AppState;
+use crate::types::HandlerResult;
+use crate::utilities::{json_response_msg, set_content_type_json};
+use hyper::{Request, Response, body::Incoming};
+use tokio::sync::oneshot;
+
+// metrics handler function
+pub fn handle_metrics(_req: Request<Incoming>, state: AppState) -> HandlerResult {
+    Box::pin(async move {
+        let (tx, rx) = oneshot::channel();
+
+        state
+            .analytics_tx
+            .send(crate::AnalyticsMessage::GetAll { reply: tx })
+            .await
+            .map_err(|_| ApiError::ActorUnavailable)?;
+
+        let data = rx.await.map_err(|_| ApiError::ActorFailed)?;
+
+        let mut response = Response::new(json_response_msg(data));
+        set_content_type_json(&mut response);
+
+        Ok(response)
+    })
+}

--- a/src/lib/routes/mod.rs
+++ b/src/lib/routes/mod.rs
@@ -1,9 +1,19 @@
 // src/lib/routes/mod.rs
 
 // module declarations
+pub mod count;
+pub mod echo;
+pub mod health;
+pub mod metrics;
+pub mod ping;
 pub mod router;
 pub mod router_table;
 
 // re-exports
+pub use count::*;
+pub use echo::*;
+pub use health::*;
+pub use metrics::*;
+pub use ping::*;
 pub use router::*;
 pub use router_table::*;

--- a/src/lib/routes/ping.rs
+++ b/src/lib/routes/ping.rs
@@ -1,0 +1,51 @@
+// src/lib/routes/ping.rs
+
+// dependencies
+use crate::actors::AnalyticsMessage;
+use crate::actors::ping::PingMessage;
+use crate::errors::ApiError;
+use crate::state::AppState;
+use crate::types::HandlerResult;
+use crate::utilities::{json_response_msg, set_content_type_json};
+use hyper::{Request, Response, body::Incoming};
+use serde::Serialize;
+use tokio::sync::oneshot;
+
+// struct type to represent a response body from the /ping endpoint
+#[derive(Serialize)]
+struct PingResponse {
+    msg: String,
+}
+
+// ping handler function
+pub fn handle_ping(_req: Request<Incoming>, state: AppState) -> HandlerResult {
+    Box::pin(async move {
+        tracing::info!("Ping endpoint reached");
+
+        state
+            .ping_tx
+            .send(PingMessage::Ping)
+            .await
+            .map_err(|_| ApiError::ActorUnavailable)?;
+
+        let (tx, rx) = oneshot::channel();
+
+        state
+            .analytics_tx
+            .send(AnalyticsMessage::Increment {
+                key: "ping".to_string(),
+                reply: tx,
+            })
+            .await
+            .map_err(|_| ApiError::ActorUnavailable)?;
+
+        rx.await.map_err(|_| ApiError::ActorFailed)?;
+
+        let mut response = Response::new(json_response_msg(PingResponse {
+            msg: "Pong".to_string(),
+        }));
+        set_content_type_json(&mut response);
+
+        Ok(response)
+    })
+}

--- a/src/lib/routes/router.rs
+++ b/src/lib/routes/router.rs
@@ -1,117 +1,13 @@
 // src/lib/routes/router.rs
 
 // dependencies
-use crate::actors::analytics::AnalyticsMessage;
-use crate::actors::ping::PingMessage;
+
 use crate::errors::ApiError;
 use crate::state::AppState;
-use crate::utilities::{empty, json_response_msg, set_content_type_json};
-use http_body_util::combinators::BoxBody;
-use hyper::body::{Bytes, Incoming};
-use hyper::{Error, Request, Response, StatusCode};
-use serde::Serialize;
-use std::future::Future;
-use std::pin::Pin;
-use tokio::sync::oneshot;
-
-// type aliases
-pub type HandlerFn = fn(Request<Incoming>, AppState) -> HandlerResult;
-type HandlerResult = Pin<Box<dyn Future<Output = Result<RouterResponse, ApiError>> + Send>>;
-type RouterResponse = Response<BoxBody<Bytes, Error>>;
-
-// struct type to represent a response body from the /count endpoint
-#[derive(Serialize)]
-struct CountResponse {
-    count: usize,
-}
-
-// struct type to represent a response body from the /ping endpoint
-#[derive(Serialize)]
-struct PingResponse {
-    msg: String,
-}
-
-// count handler function
-pub fn handle_count(_request: Request<Incoming>, state: AppState) -> HandlerResult {
-    Box::pin(async move {
-        tracing::info!("Count endpoint reached");
-
-        let (tx, rx) = oneshot::channel();
-        state
-            .ping_tx
-            .send(PingMessage::GetCount(tx))
-            .await
-            .map_err(|_| ApiError::ActorUnavailable)?;
-
-        let count = rx.await?;
-
-        let mut response = Response::new(json_response_msg(CountResponse { count }));
-        set_content_type_json(&mut response);
-
-        Ok(response)
-    })
-}
-
-// health check handler function
-pub fn handle_health_check(_req: Request<Incoming>, _state: AppState) -> HandlerResult {
-    Box::pin(async move {
-        tracing::info!("Health check endpoint reached");
-        Ok(Response::new(empty()))
-    })
-}
-
-// metrics handler function
-pub fn handle_metrics(_req: Request<Incoming>, state: AppState) -> HandlerResult {
-    Box::pin(async move {
-        let (tx, rx) = oneshot::channel();
-
-        state
-            .analytics_tx
-            .send(crate::AnalyticsMessage::GetAll { reply: tx })
-            .await
-            .map_err(|_| ApiError::ActorUnavailable)?;
-
-        let data = rx.await.map_err(|_| ApiError::ActorFailed)?;
-
-        let mut response = Response::new(json_response_msg(data));
-        set_content_type_json(&mut response);
-
-        Ok(response)
-    })
-}
-
-// ping handler function
-pub fn handle_ping(_req: Request<Incoming>, state: AppState) -> HandlerResult {
-    Box::pin(async move {
-        tracing::info!("Ping endpoint reached");
-
-        state
-            .ping_tx
-            .send(PingMessage::Ping)
-            .await
-            .map_err(|_| ApiError::ActorUnavailable)?;
-
-        let (tx, rx) = oneshot::channel();
-
-        state
-            .analytics_tx
-            .send(AnalyticsMessage::Increment {
-                key: "ping".to_string(),
-                reply: tx,
-            })
-            .await
-            .map_err(|_| ApiError::ActorUnavailable)?;
-
-        rx.await.map_err(|_| ApiError::ActorFailed)?;
-
-        let mut response = Response::new(json_response_msg(PingResponse {
-            msg: "Pong".to_string(),
-        }));
-        set_content_type_json(&mut response);
-
-        Ok(response)
-    })
-}
+use crate::types::RouterResponse;
+use crate::utilities::empty;
+use hyper::body::Incoming;
+use hyper::{Request, Response, StatusCode};
 
 // router function; routes incoming requests to send back the appropriate response
 pub async fn router(

--- a/src/lib/routes/router_table.rs
+++ b/src/lib/routes/router_table.rs
@@ -1,7 +1,7 @@
 // src/lib/routes/router_table.rs
 
 // dependencies
-use crate::routes::router::HandlerFn;
+use crate::types::HandlerFn;
 use hyper::Method;
 use matchit::{Params, Router as MatchitRouter};
 use std::collections::HashMap;

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -1,0 +1,17 @@
+// src/lib/types.rs
+
+// dependencies
+use crate::errors::ApiError;
+use crate::state::AppState;
+use http_body_util::combinators::BoxBody;
+use hyper::{
+    Error, Request, Response,
+    body::{Bytes, Incoming},
+};
+use std::{future::Future, pin::Pin};
+
+// type aliases
+pub(crate) type HandlerFn = fn(Request<Incoming>, AppState) -> HandlerResult;
+pub(crate) type HandlerResult =
+    Pin<Box<dyn Future<Output = Result<RouterResponse, ApiError>> + Send>>;
+pub(crate) type RouterResponse = Response<BoxBody<Bytes, Error>>;

--- a/src/lib/utilities.rs
+++ b/src/lib/utilities.rs
@@ -9,6 +9,7 @@ use hyper::body::Bytes;
 use hyper::header::{CONTENT_TYPE, HeaderValue};
 use hyper::{Error, Response};
 use serde::Serialize;
+use std::collections::HashMap;
 use tokio::signal;
 
 // utility function which provides a shutdown signal; leverage Tokio::signal
@@ -41,4 +42,18 @@ pub fn json_response_msg<T: Serialize>(value: T) -> BoxBody<Bytes, Error> {
     Full::new(Bytes::from(json))
         .map_err(|never| match never {})
         .boxed()
+}
+
+// utility to parse query parameters into individual pieces
+// Parse "key=value&foo=bar" into HashMap<String, String>
+pub fn parse_query_string(query: &str) -> HashMap<String, String> {
+    query
+        .split('&')
+        .filter_map(|pair| {
+            let mut parts = pair.splitn(2, '=');
+            let key = parts.next()?;
+            let value = parts.next().unwrap_or("");
+            Some((key.to_string(), value.to_string()))
+        })
+        .collect()
 }

--- a/tests/api/echo.rs
+++ b/tests/api/echo.rs
@@ -1,0 +1,33 @@
+// tests/api/echo.rs
+
+// dependencies
+use crate::helpers::{get_test_client, start_test_server};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct EchoResponse {
+    foo: String,
+    bar: String,
+}
+
+#[tokio::test]
+async fn echo_query_param() {
+    // Arrange
+    let addr = start_test_server().await;
+    let client = get_test_client();
+
+    // Act
+    let resp = client
+        .get(format!("http://{}/echo?foo=hello&bar=world", addr))
+        .send()
+        .await
+        .expect("Request to /echo failed");
+
+    // Assert
+    assert_eq!(resp.status(), 200);
+
+    let body: EchoResponse = resp.json().await.expect("Failed to parse JSON response");
+
+    assert_eq!(body.foo, "hello");
+    assert_eq!(body.bar, "world");
+}

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -2,6 +2,7 @@
 
 mod analytics;
 mod count;
+mod echo;
 mod health;
 mod helpers;
 mod ping;


### PR DESCRIPTION
Changes:
- add ability to obtain query parameters from incoming requests
- add /echo endpoint which echos back the extracted query paramaters
- add associated integration test
- re-factor to split out routes into individual modules, add module for common types